### PR TITLE
Prot Paladin Rotation Fixes

### DIFF
--- a/Rotations/paladin_protadin.lua
+++ b/Rotations/paladin_protadin.lua
@@ -43,37 +43,4 @@ function paladin_protadin(self)
    return spell
 
 end
-function paladin_protadin(self)
-	-- Credit (and thanks!) go to scottland3.
-   local rfury = UnitAura("player","Righteous Fury")
-   local myHealth = UnitHealth("player")/UnitHealthMax("player")
-   local myMana = UnitMana("player")/UnitManaMax("player")
-   local power = UnitPower("player","9")
-   local spell = nil
 
-
-   if myMana < .75 and cd("Divine Plea")==0 then 
-      spell = "Divine Plea"
-   elseif UnitIsEnemy("player", "target") and jps.should_kick("target") and cd("Rebuke") == 0 and IsSpellInRange("Rebuke", "target") == 1 then
-      SpellStopCasting() spell = "Rebuke"
-   elseif power>=3 and cd("Shield of the Righteous")==0 then
-      spell = "Shield of the Righteous"
-   elseif cd("Hammer of the Righteous")==0 then
-      spell = "Hammer of the Righteous"
-   elseif myMana > .5 and cd("Consecration")==0 then
-      spell = "Consecration"
-   elseif cd("Holy Wrath")==0 then
-      spell = "Holy Wrath"
-   elseif cd("Avenger's Shield")==0 then 
-      spell = "Avenger's Shield"
-   elseif cd("Judgement")==0 then 
-      spell = "Judgement"
-   elseif cd("Hammer of Wrath")==0 then
-      spell = "Hammer of Wrath"
-   elseif cd("crusader's strike") == 0 then
-      spell = "crusader strike"
-   end
-   
-   return spell
-
-end


### PR DESCRIPTION
Issues I fixed:
1. Priority given to CS/HotR to keep them on cooldown, generating as much Holy Power as possible.
2. Worked in the jps.MultiTarget to affect the use of HotR over CS in AoE situations, as well as using Inquisition to boost AoE DPS/Threat.
3. Added conditional use of maxed Holy Power, at health less than 70%, use WoG. In AoE use Inq. Otherwise, SotR. (The WoG heal is situational in raids, but solo this is a pretty good rule.)
4. Added priority to Grand Crusader procs, forcing the use of AvS over CS/HotR to gain the same HP but still catch the proc (6 secs).
5. Original typo found in first request. (Whoops)
