### PR TITLE
I've got a bug with write function the lua error returns a concatenation 

### DIFF
--- a/jps.lua
+++ b/jps.lua
@@ -51,8 +51,10 @@ combatFrame:RegisterEvent("ACTIVE_TALENT_GROUP_CHANGED")
 
 
 function write(...)
-	DEFAULT_CHAT_FRAME:AddMessage("|cffff8000JPS: " .. strjoin(" ", ...), 1, 1, 1);
+	DEFAULT_CHAT_FRAME:AddMessage("|cffff8000JPS: " .. strjoin(" ", tostringall(...)));
 end
+
+
 
 function combatEventHandler(self, event, ...)
 	


### PR DESCRIPTION
I've got a bug with write function the lua error returns a concatenation with boolean value
so this DEFAULT_CHAT_FRAME:AddMessage("|cffff8000JPS: " .. strjoin(" ", tostringall(...))); solved the error
