### PR TITLE
fix for raidstatus

### DIFF
--- a/jps.lua
+++ b/jps.lua
@@ -135,7 +135,7 @@ function combatEventHandler(self, event, ...)
         if UnitIsFriend("player",unit) then
 			local delta = 0
 			local hp = jps.hpInc(unit)
-
+            unit = UnitName(unit)  -- to avoid that party1, focus and target are added  all refering to the same player
 			if jps.RaidStatus[unit] then
 				delta = jps.RaidStatus[unit]["hp"] - hp end
 			jps.RaidStatus[unit] = { ["hp"] = hp, ["hpabs"] = UnitHealth(unit), ["hpmax"] = UnitHealthMax(unit), ["delta"] = delta }


### PR DESCRIPTION
avoid duplicates in raid status; now each player/pet will only show up once

before, partyX, target and focus could be each present all referring to
same partymember/pet
