### PR TITLE
jps.PVPInterrupt was not initialized

### DIFF
--- a/jps.lua
+++ b/jps.lua
@@ -27,6 +27,7 @@ jps.Class = nil
 jps.Spec = nil
 jps.Race = nil
 jps.Rotation = nil
+jps.PVPInterrupt = false
 jps.Interrupts = true
 jps.Debug = false
 jps.PLuaFlag = false


### PR DESCRIPTION
it is set to false, I use it in disc priest rotation to do damage
