### PR TITLE
Update jpdata.lua

### DIFF
--- a/jpdata.lua
+++ b/jpdata.lua
@@ -198,6 +198,7 @@ end
 
 function jps.cooldown(spell)
 	local start,duration,_ = GetSpellCooldown(spell)
+	if start == nil then return 0 end
 	local cd = start+duration-GetTime()-jps.Lag
 	if cd < 0 then return 0 end
 	return cd


### PR DESCRIPTION
I've a lowlvl druid with an unknown spell in rotation so
I've got an error because start is nil and the 
local cd = start+duration-GetTime()-jps.Lag can't be perform
in this case i've add if start == nil then return 0 end
