### PR TITLE
Update Rotations/priest_disc.lua

### DIFF
--- a/Rotations/priest_disc.lua
+++ b/Rotations/priest_disc.lua
@@ -11,6 +11,7 @@ local average_POH = getaverage_heal("Prayer of Healing")
 ----------------------
 -- HELPER
 ----------------------
+
 --IsControlKeyDown(): debug print text
 --AltKey_IsDown : "Mass Dispel"
 --jps.Defensive: Heal only the Tank et yourself 	/jps def
@@ -19,36 +20,38 @@ local average_POH = getaverage_heal("Prayer of Healing")
 --jps.UseCDs: group heal "Prayer of Healing"		/jps cds
 --jps.Interrupts : "Pain Suppression"				/jps int
 
+local AltKey_IsDown = false
+if IsAltKeyDown() then AltKey_IsDown = true end
+
 local spell = nil
 local playerhealth_deficiency = UnitHealthMax("player")-UnitHealth("player")
 local playerhealth_pct = UnitHealth("player") / UnitHealthMax("player")
-
-local PriestHeal_Target = jps.lowestInRaidStatus() -- jps.HealingTarget()
-local health_deficiency = UnitHealthMax(PriestHeal_Target) - UnitHealth(PriestHeal_Target)
-local health_pct = jps.hpInc(PriestHeal_Target) -- UnitHealth(PriestHeal_Target) / UnitHealthMax(PriestHeal_Target)
 
 -- number of party members having a significant health pct loss
 local countInRaid = 3
 local pctLOSS = 0.80
 local POH_countInRaid = jps.countInRaidStatus(pctLOSS) 
 local findSubGroup, POH_Target = jps.findSubGroupToHeal(pctLOSS) -- returns the subgroup and the target to heal with POH in RAID
-
 local borrowed = jps.buff("Borrowed Time", "player")
-local div_Aegis = jps.buff("Divine Aegis", PriestHeal_Target)
-
-local AltKey_IsDown = false
-if IsAltKeyDown() then AltKey_IsDown = true end 
 
 ----------------------------
 -- PriestHeal_Target_TANK
 ----------------------------
 
+local PriestHeal_Target = jps.lowestInRaidStatus() -- jps.HealingTarget()
+local health_deficiency = UnitHealthMax(PriestHeal_Target) - UnitHealth(PriestHeal_Target)
+local health_pct = jps.hpInc(PriestHeal_Target) -- UnitHealth(PriestHeal_Target) / UnitHealthMax(PriestHeal_Target)
+
 local Tanktable = {}
 local PriestHeal_Target_TANK = nil
-if UnitExists("focus") == nil then 
+local switchtoLowestTarget = false
+
+if UnitExists("focus") == nil then
 	PriestHeal_Target_TANK = PriestHeal_Target
-elseif UnitExists("focus")==1 and UnitIsEnemy("player","focus")==1 then
+	switchtoLowestTarget = true
+elseif (UnitExists("focus")==1 and UnitIsEnemy("player","focus")==1) then
 	PriestHeal_Target_TANK = PriestHeal_Target
+	switchtoLowestTarget = true
 else
 	table.insert(Tanktable,"player")
 	if UnitExists("target") and UnitIsFriend("player","target") then table.insert(Tanktable,"target") end
@@ -69,11 +72,13 @@ local health_deficiency_TANK = UnitHealthMax(PriestHeal_Target_TANK) - UnitHealt
 local health_pct_TANK = jps.hpInc(PriestHeal_Target_TANK) -- UnitHealth(PriestHeal_Target_TANK) / UnitHealthMax(PriestHeal_Target_TANK)
 local stackGrace_TANK = jps.buffStacks("Grace",PriestHeal_Target_TANK)
 
-local switchtoLowestTarget = false
-if (health_pct < 0.60) or (health_pct_TANK > 0.90 and jps.buff("Renew", PriestHeal_Target_TANK)) or (health_pct_TANK > 0.90 and stackGrace_TANK > 2) then
-	switchtoLowestTarget = true 
+if (health_pct_TANK > 0.80) and jps.buff("Renew", PriestHeal_Target_TANK) then
+	switchtoLowestTarget = true
+elseif (health_pct_TANK > 0.80) and stackGrace_TANK > 2 then
+	switchtoLowestTarget = true
+elseif (health_pct < 0.60) and not jps.Defensive then -- Heal only Tank 
+	switchtoLowestTarget = true
 end
-if jps.Defensive then switchtoLowestTarget = false end
 
 ----------------------
 -- DAMAGE
@@ -92,6 +97,7 @@ end
 -- DISPEL
 ---------------------
 
+local castDeath = jps.MageSheepDuration(rangedTarget) -- return true/false
 local stunMe = jps.isStun() -- return true/false
 local dispelOffensive_Target = jps.canDispellOffensive(rangedTarget) -- return true/false
 
@@ -132,74 +138,44 @@ end
 -- TRINKETS ------------
 ------------------------
 
-	local spellstop, _, _, _, _, endTime = UnitCastingInfo("player")
 -- kick Spell Heal if LowHeath
-	if spellstop == "Heal" and (endTime-GetTime()) > 1 and health_pct < 0.70 then SpellStopCasting() end
+	local spellstop = UnitCastingInfo("player")
+	if spellstop == "Heal" and jps.castTimeLeft("player") > 1 and health_pct < 0.70 then
+		SpellStopCasting()
+	end
 -- Don't kick Casting
 	if UnitCastingInfo("player") or UnitChannelInfo("player") then return nil end
 
 -- Trinket
-	if  IsEquippedItem("Foul Gift of the Demon Lord") and select(1,GetItemCooldown(72898))==0 and IsUsableItem("Foul Gift of the Demon Lord") and UnitAffectingCombat("player")==1 and div_Aegis then 
+	if  IsEquippedItem("Foul Gift of the Demon Lord") and select(1,GetItemCooldown(72898))==0 and IsUsableItem("Foul Gift of the Demon Lord") and UnitAffectingCombat("player")==1 then 
 		RunMacroText("/use Foul Gift of the Demon Lord")
 	elseif IsEquippedItem("Fiery Quintessence") and select(1,GetItemCooldown(69000))==0 and IsUsableItem("Fiery Quintessence") and UnitAffectingCombat("player")==1 then 
 		RunMacroText("/use Fiery Quintessence")
+	elseif stunMe and IsEquippedItem("Ruthless Gladiator's Medallion of Tenacity") and select(1,GetItemCooldown(72412))==0 
+	and IsUsableItem("Ruthless Gladiator's Medallion of Tenacity") and UnitAffectingCombat("player")==1 then 
+		RunMacroText("/use Ruthless Gladiator's Medallion of Tenacity")
 	end
 
 ------------------------
 -- SPELL TABLE ---------
 ------------------------
+
 local spellTable_moving =
 {
 	{ "Pain Suppression", jps.Interrupts and (playerhealth_pct < 0.30), "player" },
 	{ "Pain Suppression", jps.Interrupts and (health_pct < 0.30), PriestHeal_Target },
-	{ "Desperate Prayer", select(2,GetSpellBookItemInfo("Desperate Prayer"))~=nil and (playerhealth_pct < 0.40) , "player" },
-	{ "Power Word: Shield", (playerhealth_pct < 0.60) and not jps.buff("Power Word: Shield","player") and not jps.debuff("Weakened Soul","player") , "player" },
-	{ "Power Word: Shield", (health_pct < 0.60) and not jps.debuff("Weakened Soul",PriestHeal_Target) and not jps.buff("Power Word: Shield",PriestHeal_Target) , PriestHeal_Target },
+	{ "Desperate Prayer", select(2,GetSpellBookItemInfo("Desperate Prayer"))~=nil and (playerhealth_pct < 0.40), "player" },
+	{ "Power Word: Shield", (playerhealth_pct < 0.60) and not jps.buff("Power Word: Shield","player") and not jps.debuff("Weakened Soul","player"), "player" },
+	{ "Power Word: Shield", (health_pct < 0.60) and not jps.buff("Power Word: Shield",PriestHeal_Target) and not jps.debuff("Weakened Soul",PriestHeal_Target), PriestHeal_Target },
+	{ "Gift of the Naaru", select(2,GetSpellBookItemInfo("Gift of the Naaru"))~=nil and (playerhealth_pct < 0.80), "player" },
+	{ "Gift of the Naaru", select(2,GetSpellBookItemInfo("Gift of the Naaru"))~=nil and (health_pct < 0.80), PriestHeal_Target },
+	{ "Prayer of Mending", not jps.buff("Prayer of Mending","player") and (playerhealth_pct < 0.80), "player" },
+	{ "Prayer of Mending", not jps.buff("Prayer of Mending",PriestHeal_Target) and (health_pct < 0.80), PriestHeal_Target },
 	{ "Renew", not jps.buff("Renew","player") and (playerhealth_deficiency > average_renew), "player" },
 	{ "Renew", not jps.buff("Renew",PriestHeal_Target) and (health_deficiency > average_renew), PriestHeal_Target },
-	{ "Prayer of Mending", not jps.buff("Prayer of Mending","player") and (playerhealth_pct < 0.60), "player" },
-	{ "Prayer of Mending", not jps.buff("Prayer of Mending",PriestHeal_Target) and (health_pct < 0.60), PriestHeal_Target },
-	{ "Gift of the Naaru", select(2,GetSpellBookItemInfo("Gift of the Naaru"))~=nil and (playerhealth_pct < 0.80) , "player" },
-	{ "Gift of the Naaru", select(2,GetSpellBookItemInfo("Gift of the Naaru"))~=nil and (health_pct < 0.80) , PriestHeal_Target },
+	{ "Power Word: Shield", UnitIsPVP("player")==1 and not jps.buff("Power Word: Shield","player") and not jps.debuff("Weakened Soul","player"), "player" },
+	{ "Dispel Magic", jps.MultiTarget and dispelMagic_Me, "player" },
 	{ "Dispel Magic", jps.MultiTarget and UnitExists(dispelMagic_Target)==1 , dispelMagic_Target },
-}
-
-local spellTable_def =
-{
--- Emergency player
-	{"nested", (playerhealth_pct < 0.60),
-		{
-			{ "Desperate Prayer", select(2,GetSpellBookItemInfo("Desperate Prayer"))~=nil and (playerhealth_pct < 0.40), "player" }, -- IsSpellKnown(spellID)
-			{ "Pain Suppression", jps.Interrupts and (playerhealth_pct < 0.30), "player"},
-			{ "Flash Heal", jps.buff("Inner Focus","player"), "player"},
-			{ "Penance", "onCD" , "player"},
-			{ "Power Word: Shield", not jps.buff("Power Word: Shield","player") and not jps.debuff("Weakened Soul","player"), "player"},
-			{ "Greater Heal", borrowed, "player" },
-			{ "Gift of the Naaru", select(2,GetSpellBookItemInfo("Gift of the Naaru"))~=nil and (playerhealth_pct < 0.80) , "player" },
-			{ "Prayer of Mending", not jps.buff("Prayer of Mending","player") ,"player"},
-			{ "Binding Heal", UnitIsUnit(PriestHeal_Target, "player")~=1 and (playerhealth_deficiency > average_flashheal), PriestHeal_Target},
-			{ "Flash Heal", "onCD", "player"},
-		},
-	},
--- Focus Heal
-	{"nested", jps.canHeal(PriestHeal_Target_TANK),
-		{
-			{ "Pain Suppression", jps.Interrupts and (health_pct_TANK < 0.30), PriestHeal_Target_TANK },
-			{ "Penance", stackGrace_TANK < 3 and UnitAffectingCombat("player")==1, PriestHeal_Target_TANK }, 
-			{ "Flash Heal", jps.buff("Inner Focus","player") and health_deficiency_TANK > (average_flashheal + average_renew) , PriestHeal_Target_TANK },
-			{ "Power Word: Shield", not jps.debuff("Weakened Soul",PriestHeal_Target_TANK) and not jps.buff("Power Word: Shield",PriestHeal_Target_TANK), PriestHeal_Target_TANK },
-			{ "Penance", health_deficiency_TANK > (average_penitence + average_renew), PriestHeal_Target_TANK },
-			{ "Greater Heal", borrowed and health_deficiency_TANK > (average_greater_heal + average_renew), PriestHeal_Target_TANK },
-			{ "Prayer of Mending", not jps.buff("Prayer of Mending",PriestHeal_Target_TANK), PriestHeal_Target_TANK },
-			{ "Binding Heal", UnitIsUnit(PriestHeal_Target_TANK, "player")~=1 and (playerhealth_deficiency > average_flashheal), PriestHeal_Target_TANK },
-			{ "Flash Heal", health_pct_TANK < 0.60 , PriestHeal_Target_TANK },
-			{ "Greater Heal", health_deficiency_TANK > (average_greater_heal + average_renew), PriestHeal_Target_TANK },
-			{ "Renew", not jps.buff("Renew",PriestHeal_Target_TANK), PriestHeal_Target_TANK },
-			{ "Binding Heal", UnitIsUnit(PriestHeal_Target,"player")~=1 and (playerhealth_deficiency > average_flashheal), PriestHeal_Target },
-			{ "Gift of the Naaru", select(2,GetSpellBookItemInfo("Gift of the Naaru"))~=nil and (health_pct_TANK < 0.80), PriestHeal_Target_TANK },
-			{ "Heal", (health_pct_TANK < 1), PriestHeal_Target_TANK },
-		},
-	},
 }
 
 local spellTable_main =
@@ -210,12 +186,11 @@ local spellTable_main =
  	{ "Fade", UnitIsPVP("player")~=1 and UnitThreatSituation("player")==3, "player" },
  	{ "Inner Focus", UnitAffectingCombat("player")==1 , "player" },
  	{ "Fear Ward", UnitIsPVP("player")==1 and not jps.buff("Fear Ward","player"), "player" },
- 	{ "Desperate Prayer", select(2,GetSpellBookItemInfo("Desperate Prayer"))~=nil and (playerhealth_pct < 0.40), "player" },
  	{ "Power Word: Shield", timerShield == 0 and not jps.debuff("Weakened Soul", PriestHeal_Target_TANK) and not jps.buff("Power Word: Shield", PriestHeal_Target_TANK), PriestHeal_Target_TANK },
 	{ "Power Word: Shield", UnitIsUnit(PriestHeal_Target_TANK, "focustargettarget")~=1 and jps.canHeal("focustargettarget") and not jps.debuff("Weakened Soul","focustargettarget") and not jps.buff("Power Word: Shield","focustargettarget"), "focustargettarget"},
 -- Dispell
  	{ "Mass Dispel", AltKey_IsDown, "player" },
- 	{ "nested", (health_pct > 0.60) and jps.MultiTarget,
+ 	{ "nested", (health_pct_TANK > 0.60) and jps.MultiTarget,
         {
 			{"Dispel Magic", dispelMagic_Me, "player" },
 			{"Cure Disease", dispelDisease_Me, "player" },
@@ -228,6 +203,7 @@ local spellTable_main =
 -- Damage
 	{ "nested", jps.PVPInterrupt and UnitExists(rangedTarget)==1,
         {
+        	{ "Shadow Word: Death", castDeath, rangedTarget},
         	{ "Dispel Magic", dispelOffensive_Target, rangedTarget },
             { "Shadow Word: Death", UnitHealth(rangedTarget)/UnitHealthMax(rangedTarget) < 0.25, rangedTarget },
             { "Holy Fire", "onCD", rangedTarget },
@@ -251,30 +227,62 @@ local spellTable_main =
     },
 	{ "nested", jps.UseCDs and (POH_countInRaid > countInRaid),
         {
-            { "Prayer of Healing", jps.UseCDs and (findSubGroup > 0) and jps.canHeal(POH_Target), POH_Target},
-    		{ "Prayer of Healing", jps.UseCDs and (findSubGroup > 0), "player"},
-			{ "Prayer of Healing", jps.UseCDs and (findSubGroup == 0) and jps.canHeal(PriestHeal_Target), PriestHeal_Target},
-    		{ "Prayer of Healing", jps.UseCDs and (findSubGroup == 0), "player"},
+            { "Prayer of Healing", (findSubGroup > 0) and jps.canHeal(POH_Target), POH_Target},
+    		{ "Prayer of Healing", (findSubGroup > 0), "player"},
+			{ "Prayer of Healing", (findSubGroup == 0) and jps.canHeal(PriestHeal_Target), PriestHeal_Target},
+    		{ "Prayer of Healing", (findSubGroup == 0), "player"},
         },
     },
+-- Emergency player
+	{ "nested", (playerhealth_pct < 0.60),
+		{
+			{ "Desperate Prayer", select(2,GetSpellBookItemInfo("Desperate Prayer"))~=nil and (playerhealth_pct < 0.40), "player" }, -- IsSpellKnown(spellID)
+			{ "Pain Suppression", jps.Interrupts and (playerhealth_pct < 0.30), "player"},
+			{ "Flash Heal", jps.buff("Inner Focus","player"), "player"},
+			{ "Penance", "onCD" , "player"},
+			{ "Power Word: Shield", not jps.buff("Power Word: Shield","player") and not jps.debuff("Weakened Soul","player"), "player"},
+			{ "Greater Heal", borrowed, "player" },
+			{ "Gift of the Naaru", select(2,GetSpellBookItemInfo("Gift of the Naaru"))~=nil and (playerhealth_pct < 0.80) , "player" },
+			{ "Prayer of Mending", not jps.buff("Prayer of Mending","player") ,"player"},
+			{ "Binding Heal", UnitIsUnit(PriestHeal_Target_TANK, "player")~=1 and (playerhealth_deficiency > average_flashheal), PriestHeal_Target_TANK},
+			{ "Flash Heal", "onCD", "player"},
+		},
+	},
+-- Boss Debuff
+	{ "Greater Heal", not switchtoLowestTarget and UnitExists(Plasma)==1, Plasma }, -- "Deathwing"
+-- Focus Heal
+	{ "nested", not switchtoLowestTarget and jps.canHeal(PriestHeal_Target_TANK),
+		{
+			{ "Pain Suppression", jps.Interrupts and (health_pct_TANK < 0.30), PriestHeal_Target_TANK },
+			{ "Penance", stackGrace_TANK < 3 and UnitAffectingCombat("player")==1, PriestHeal_Target_TANK }, 
+			{ "Flash Heal", jps.buff("Inner Focus","player") and health_deficiency_TANK > (average_flashheal + average_renew) , PriestHeal_Target_TANK },
+			{ "Power Word: Shield", not jps.debuff("Weakened Soul",PriestHeal_Target_TANK) and not jps.buff("Power Word: Shield",PriestHeal_Target_TANK), PriestHeal_Target_TANK },
+			{ "Penance", health_deficiency_TANK > (average_penitence + average_renew), PriestHeal_Target_TANK },
+			{ "Greater Heal", borrowed and health_deficiency_TANK > (average_greater_heal + average_renew), PriestHeal_Target_TANK },
+			{ "Prayer of Mending", not jps.buff("Prayer of Mending",PriestHeal_Target_TANK), PriestHeal_Target_TANK },
+			{ "Gift of the Naaru", select(2,GetSpellBookItemInfo("Gift of the Naaru"))~=nil and (health_pct_TANK < 0.80), PriestHeal_Target_TANK },
+			{ "Renew", not jps.buff("Renew",PriestHeal_Target_TANK), PriestHeal_Target_TANK },
+			{ "Binding Heal", UnitIsUnit(PriestHeal_Target_TANK, "player")~=1 and (playerhealth_deficiency > average_flashheal), PriestHeal_Target_TANK },
+			{ "Flash Heal", health_pct_TANK < 0.60 , PriestHeal_Target_TANK },
+			{ "Greater Heal", health_deficiency_TANK > (average_greater_heal + average_renew), PriestHeal_Target_TANK },
+			{ "Heal", (health_pct_TANK < 1), PriestHeal_Target_TANK },
+		},
+	},
 -- Emergency Target
 	{ "Pain Suppression", jps.Interrupts and (health_pct < 0.30), PriestHeal_Target },
 	{ "Penance", health_deficiency > (average_penitence + average_renew), PriestHeal_Target },
 	{ "Flash Heal", jps.buff("Inner Focus","player") and health_deficiency > (average_flashheal + average_renew), PriestHeal_Target },
+	{ "Prayer of Mending", not jps.buff("Prayer of Mending",PriestHeal_Target), PriestHeal_Target },
+	{ "Power Word: Shield", (health_pct < 0.60) and not jps.debuff("Weakened Soul",PriestHeal_Target) and not jps.buff("Power Word: Shield",PriestHeal_Target), PriestHeal_Target },
 	{ "Greater Heal", borrowed and health_deficiency > (average_greater_heal + average_renew), PriestHeal_Target },
 	{ "Binding Heal", UnitIsUnit(PriestHeal_Target,"player")~=1 and (playerhealth_deficiency > average_flashheal), PriestHeal_Target },
-	{ "Power Word: Shield", (health_pct < 0.60) and not jps.debuff("Weakened Soul",PriestHeal_Target) and not jps.buff("Power Word: Shield",PriestHeal_Target), PriestHeal_Target },
-	{ "Prayer of Mending", (health_pct < 0.60) and not jps.buff("Prayer of Mending",PriestHeal_Target), PriestHeal_Target }, 
 	{ "Flash Heal", (health_pct < 0.60), PriestHeal_Target },
--- Boss Debuff
-	{ "Greater Heal", UnitExists(Plasma)==1 , Plasma }, -- "Deathwing"
 -- Basic    
 	{ "Gift of the Naaru", select(2,GetSpellBookItemInfo("Gift of the Naaru"))~=nil and (health_pct < 0.80), PriestHeal_Target },
 	{ "Greater Heal", health_deficiency > (average_greater_heal + average_renew) and jps.buff("Renew",PriestHeal_Target) and jps.buffDuration("Renew", PriestHeal_Target) < 3, PriestHeal_Target },
-	{ "Greater Heal", health_deficiency > (average_greater_heal + average_renew) and not jps.buff("Renew",PriestHeal_Target), PriestHeal_Target },
 	{ "Greater Heal", health_deficiency > (average_greater_heal + average_renew), PriestHeal_Target },
 	{ "Renew", not jps.buff("Renew",PriestHeal_Target) and (health_deficiency > average_renew) , PriestHeal_Target },
-	{ "Renew", jps.buff("Power Word: Shield",PriestHeal_Target) and health_deficiency < (average_penitence + average_renew) and health_deficiency > average_heal and not jps.buff("Renew",PriestHeal_Target), PriestHeal_Target },
+	{ "Renew", jps.buff("Power Word: Shield",PriestHeal_Target) and not jps.buff("Renew",PriestHeal_Target) and health_deficiency < (average_penitence + average_renew) and health_deficiency > average_heal, PriestHeal_Target },
 	{ "Heal", jps.buff("Renew",PriestHeal_Target) and jps.buffDuration("Renew", PriestHeal_Target) < 3 and health_deficiency > (average_heal + average_renew), PriestHeal_Target },
 	{ "Heal", (health_deficiency > average_renew), PriestHeal_Target },
 }
@@ -282,8 +290,6 @@ local spellTable_main =
 local target = nil
 if (GetUnitSpeed("player") / 7) > 0 then
 	spell, target = parseSpellTable(spellTable_moving)
-elseif jps.Defensive then
-	spell, target = parseSpellTable(spellTable_def)
 else
 	spell, target = parseSpellTable(spellTable_main)
 end
@@ -319,3 +325,38 @@ else
 end 
 local spell,target = parseSpellTable(spellTable)
 ]]
+
+-- Inner Focus - Focalisation intérieure
+-- Power Infusion - Infusion de puissance
+-- Fade - Oubli
+-- Mass Dispel - Dissipation de masse
+-- Pain Suppression - Suppression de la douleur
+-- Gift of the Naaru - Don des naaru
+-- Penance - Pénitence
+-- Grace - Grâce
+-- Divine Aegis - Egide divine - Critical heals and all heals from Prayer of Healing create a protective shield on the target
+-- Weakened Soul - Ame affaiblie
+-- Divine Hymn - Hymne divin
+-- Dispel Magic - Dissipation de la magie
+-- Inner Fire - Feu intérieur
+-- Serendipity - Heureux hasard
+-- Power Word: Fortitude - Mot de pouvoir : Robustesse
+-- Fear Ward - Gardien de peur
+-- Chakra: Serenity - Chakra : Sérénité
+-- Chakra - Chakra
+-- Heal - Soins
+-- Flash Heal - Soins rapides
+-- Binding Heal - Soins de lien
+-- Greater Heal - Soins supérieurs
+-- Renew - Rénovation
+-- Circle of Healing - Cercle de soins
+-- Prayer of Healing - Prière de soins
+-- Prayer of Mending - Prière de guérison
+-- Guardian Spirit - Esprit gardien
+-- Cure Disease - Guérison des maladies
+-- Desperate Prayer - Prière du désespoir
+-- Surge of light - Vague de Lumière
+-- Holy Word: Serenity - Mot sacré : Sérénité SpellID 88684
+-- Power Word: Shield - Mot de pouvoir : Bouclier
+-- Borrowed Time - Sursis - votre prochain sort d'un bonus à la hâte des sorts après avoir lancé Mot de pouvoir : Bouclier. Dure 6 sec.
+


### PR DESCRIPTION
only two tables, one main and one for moving
add flag local castDeath = jps.MageSheepDuration(rangedTarget)
improve the flag switchtoLowestTarget depends if we have a focus tank or not
adjust the GetSpellBookItemInfo("Desperate Prayer"))~=nil because if this spell is unknown it returns nil and it's interpreted as true in parse table
add jps.castTimeLeft for spell Heal when this spell is casting and health goes < 70%
