### PR TITLE
Update Rotations/hunter_bm.lua

### DIFF
--- a/Rotations/hunter_bm.lua
+++ b/Rotations/hunter_bm.lua
@@ -6,21 +6,26 @@ local focus = UnitMana("player")
 local pet_focus = UnitMana("pet")
 local pet_frenzy = jps.buffStacks("Frenzy Effect","pet")
 local pet_attacking = IsPetAttackActive()
+local power = UnitPower("player",6)
+
 
 local spellTable = 
 {
-{ {"macro","/petattack"}, not IsPetAttackActive() },
+{ {"hunter's mark", not jps.debuff("hunter's mark")},
+{ "macro","/petattack"}, not IsPetAttackActive() },
 { jps.DPSRacial, jps.UseCDs },
 { "bestial wrath", focus > 60 },
 { "serpent sting", not jps.debuff("serpent sting") },
 { "kill shot" },
 { "rapid fire", not jps.buff("bloodlust") and not jps.buff("the beast within") and not jps.buff("heroism") and not jps.buff("time warp") },
 { "kill command", },
+{ "cobra shot", power <= 20},
 { "dire beast", },
 { "lynx rush", },
 { "focus fire", pet_frenzy==5 and not jps.buff("the beast within")},
 { "arcane shot", focus >= 59 or jps.buff("the beast within") },
 { {"macro","/cast cobra shot"}, jps.cooldown("cobra shot") == 0 },
+{ "explosive trap", IsShiftKeyDown() and jps.MultiTarget },
 }
 
 return parseSpellTable(spellTable)


### PR DESCRIPTION
This is a small change to the BM rotation, as it 'should' cast cobra shot when focus is <=20, and it 'should' add the ability to cast explosive trap by pressing the shift key.

The thing I was not sure about was the number '6' in the local variable for power. I copied that from the Blood DK lua, so the number may be wrong. I have no idea how to figure out what the correct number is, but once that is determined (and tested), this behavior should be good to go.

Let me know if there is anything that you change, so that I can understand (and hopefully contribute more) in the future. I am going to start working on a BM PvP set next.
JU1CYFRU1T
