### PR TITLE
Update Rotations/rogue_combat.lua

### DIFF
--- a/Rotations/rogue_combat.lua
+++ b/Rotations/rogue_combat.lua
@@ -8,23 +8,21 @@ function rogue_combat(self)
 	
 	local spellTable = 
 	{
-		{ "preparation", not jps.buff("vanish") and jps.cd("vanish") > 60 },
-		{ "vanish", not jps.buff("shadow blades") and not jps.buff("adrenaline rush") and energy < 20 and ((jps.buff("deep insight") and cp < 4)) },
+		{ "preparation", 		not jps.buff("vanish") and jps.cd("vanish") > 60 },
+		{ "vanish", 			not jps.buff("shadow blades") and not jps.buff("adrenaline rush") and energy < 20 and ((jps.buff("deep insight") and cp < 4)) },
 		{ "ambush" },
-		{ "slice and dice", snd_duration < 2 or (snd_duration < 15 and jps.buffStacks("bandit's guile") == 11 and cp >= 4) },
-		{ "shadow blades", jps.bloodlusting() and snd_duration >= jps.buffDuration("shadow blades") },
-		{ "killing spree", energy < 35 and snd_duration > 4 and not jps.buff("adrenaline rush") },
-		{ "adrenaline rush", energy < 35 or jps.buff("shadow's blade") },
-		{ "rupture", rupture_duration < 4 cp == 5 and jps.buff("deep insight") },
-		{ "eviscerate", cp == 5 and jps.buff("deep insight") },
-		{ "rupture", rupture_duration < 4 and cp == 5 },
-		{ "revealing strike", jps.buff("deep insight") and cp < 5 },
-		{ "tricks of the trade" },
-		{ "sinister strike", cp < 5 },
+		{ "slice and dice", 	snd_duration < 2 or (snd_duration < 15 and jps.buffStacks("bandit's guile") == 11 and cp >= 4) },
+		{ "shadow blades", 		jps.bloodlusting() and snd_duration >= jps.buffDuration("shadow blades") },
+		{ "killing spree", 		energy < 35 and snd_duration > 4 and not jps.buff("adrenaline rush") },
+		{ "adrenaline rush", 	energy < 35 or jps.buff("shadow's blade") },
+		{ "rupture", 			rupture_duration < 4 and cp == 5 and jps.buff("deep insight") },
+		{ "eviscerate", 		cp == 5 and jps.buff("deep insight") },
+		{ "rupture", 			rupture_duration < 4 and cp == 5 },
+		{ "revealing strike", 	jps.buff("deep insight") and cp < 5 },
+--		{ "tricks of the trade" }, -- requires a friendly target to cast it on
+		{ "sinister strike", 	cp < 5 },
 	}
 
 	return parseSpellTable(spellTable)
 
 end
-
-


### PR DESCRIPTION
- Fixed error for rupture, 'and' was missing
- Commented Tricks of the Trade, requires a friendly target, so rotation got stuck
