### PR TITLE
jpevents.lua TimeToDie Fix

### DIFF
--- a/jpevents.lua
+++ b/jpevents.lua
@@ -42,6 +42,7 @@ local combatLogEventTable = {}
 function jps.registerOnUpdate(fn)
     if not updateTable[fn] then
         updateTable[fn] = fn
+        return true
     end
 end
 
@@ -51,9 +52,10 @@ end
 -- was registered earlier. 
 -- Has no effect if the function wasn't registered
 -- @param fn function to unregister
-function jps.unregisterEvent(fn)
+function jps.unregisterOnUpdate(fn)
     if  updateTable[fn] then
         updateTable[fn] = nil
+        return true
     end
 end
 
@@ -70,6 +72,7 @@ function jps.registerEvent(event, fn)
     end
     if not eventTable[event][fn] then
         eventTable[event][fn] = fn
+        return true
     end
 end
 
@@ -88,6 +91,7 @@ function jps.unregisterEvent(event, fn)
         if count == 0 then
             jpsFrame:UnregisterEvent(event)
         end
+        return true
     end
 end
 
@@ -104,6 +108,7 @@ function jps.registerCombatLogEventUnfiltered(event, fn)
     end
     if not combatLogEventTable[event][fn] then
         combatLogEventTable[event][fn] = fn
+        return true
     end
 end
 
@@ -122,6 +127,7 @@ function jps.unregisterCombatLogEventUnfiltered(event, fn)
         if count == 0 then
             jpsFrame:UnregisterEvent(event)
         end
+        return true
      end
 end
 

--- a/jps.lua
+++ b/jps.lua
@@ -465,26 +465,26 @@ end
 end
 ]]
 
-function updateTimeToDie(unit)
+function updateTimeToDie(elapsed, unit)
 	if not unit then
-			updateTimeToDie("target")
-			updateTimeToDie("focus")
-			updateTimeToDie("mouseover")
+			updateTimeToDie(elapsed, "target")
+			updateTimeToDie(elapsed, "focus")
+			updateTimeToDie(elapsed, "mouseover")
 			for id = 1, 4 do
-				updateTimeToDie("boss" .. id)
+				updateTimeToDie(elapsed, "boss" .. id)
 			end
 			if jps.isHealer then
 				for id = 1, 4 do
-					updateTimeToDie("party" .. id)
-					updateTimeToDie("partypet" .. id)
+					updateTimeToDie(elapsed, "party" .. id)
+					updateTimeToDie(elapsed, "partypet" .. id)
 				end
 				for id = 1, 5 do
-					updateTimeToDie("arena" .. id)
-					updateTimeToDie("arenapet" .. id)
+					updateTimeToDie(elapsed, "arena" .. id)
+					updateTimeToDie(elapsed, "arenapet" .. id)
 				end
 				for id = 1, 40 do
-					updateTimeToDie("raid" .. id)
-					updateTimeToDie("raidpet" .. id)
+					updateTimeToDie(elapsed, "raid" .. id)
+					updateTimeToDie(elapsed, "raidpet" .. id)
 				end
 			end
 		return


### PR DESCRIPTION
jpevents.lua: removed Logging of all events...too much if jps.Debug enabled...
jpevents.lua: jps.unregisterOnUpdate had wrong name - fixed …
jpevents.lua: (un)register function now return true, if the function was (un)registered
jps.lua: changed updateTimeToDie(unit) to updateTimeToDie(elapsed, unit) works, but doesn't look good
