### PR TITLE
Rogue Assassination not working

### DIFF
--- a/Rotations/rogue_assass.lua
+++ b/Rotations/rogue_assass.lua
@@ -7,7 +7,7 @@ function rogue_assass()
 	local rupture_duration = jps.debuffDuration("rupture")
 	local snd_duration = jps.buffDuration("slice and dice")
 	local energy = UnitMana("player")
-	local tank = jps.findMeATank()
+	local tank = jps.findMeAggroTank()
 	local spellTable =
 	{
 		{ "preparation", not jps.buff("vanish") and jps.cooldown("vanish") > 60 },


### PR DESCRIPTION
Currently this rotation just doesn't work...
Vanish will ruin solo play, and trick of the trade without target just makes this rotation do nothing...
- no more vanish if not in group
- tricks of the trade need a target...it is now either focus or the first tank (don't know if this is the best idea to auto cast on a tank)
