### PR TITLE
Update PriestDisc -  jps.UnitTimeToDie(unit) - jps_round(num, idp)

### DIFF
--- a/Rotations/priest_disc_pve.lua
+++ b/Rotations/priest_disc_pve.lua
@@ -42,7 +42,7 @@ local health_pct = jps.hpInc(jps_Target)
 
 local jps_TANK = jps.findMeATank() -- IF NOT "FOCUS" RETURN PLAYER AS DEFAULT
 local jps_FriendTTD = jps.LowestTimetoDie() -- FRIEND UNIT WITH THE LOWEST TIMETODIE or TIMETOLIVE
-local TimeToDiePlayer = jps.TimeToDie("player")
+local TimeToDiePlayer = jps.UnitTimeToDie("player")
 
 local Tanktable = { ["focus"] = 100, ["player"] = 100, ["target"] = 100, ["targetarget"] = 100, ["mouseover"] = 100 }
 if isInBG and playerhealth_pct < 0.40 then
@@ -203,7 +203,10 @@ local function unitFor_Mending(unit)
 end
 
 local function unitLoseControl(unit) -- {"CC", "Snare", "Root", "Silence", "Immune", "ImmuneSpell", "Disarm"}
-	if jps.LoseControlTable(unit) then return true end
+	if jps.LoseControl(unit,"CC") then return true end
+	if jps.LoseControl(unit,"Snare") then return true end
+	if jps.LoseControl(unit,"Root") then return true end
+	if jps.LoseControl(unit,"Silence") then return true end
 	return false
 end
 
@@ -472,6 +475,8 @@ end
 if jps.IsCastingSpell(2050,"player") and jps.CastTimeLeft(player) > 0.5 and (health_pct_TANK < 0.75) and (manapool > 0.20) then 
 	SpellStopCasting()
 	DEFAULT_CHAT_FRAME:AddMessage("STOPCASTING HEAL",0, 0.5, 0.8)
+-- Avoid interrupt Channeling
+elseif UnitChannelInfo("player")~= nil then return nil
 -- Avoid Overhealing 
 elseif jps.IsCasting("player") and (health_pct_TANK > 0.95) and (not jps.buffId(109964)) and (jps.Target == jps_TANK) then 
 	SpellStopCasting()

--- a/Rotations/priest_disc_pvp.lua
+++ b/Rotations/priest_disc_pvp.lua
@@ -42,7 +42,7 @@ local health_pct = jps.hp(jps_Target)
 
 local jps_TANK = jps.findMeATank() -- IF NOT "FOCUS" RETURN PLAYER AS DEFAULT
 local jps_FriendTTD = jps.LowestTimetoDie() -- FRIEND UNIT WITH THE LOWEST TIMETODIE or TIMETOLIVE
-local TimeToDiePlayer = jps.TimeToDie("player")
+local TimeToDiePlayer = jps.UnitTimeToDie("player")
 
 local Tanktable = { ["focus"] = 100, ["player"] = 100, ["target"] = 100, ["targetarget"] = 100, ["mouseover"] = 100 }
 if isInBG and playerhealth_pct < 0.40 then
@@ -205,7 +205,10 @@ local function unitFor_Mending(unit)
 end
 
 local function unitLoseControl(unit) -- {"CC", "Snare", "Root", "Silence", "Immune", "ImmuneSpell", "Disarm"}
-	if jps.LoseControlTable(unit) then return true end
+	if jps.LoseControl(unit,"CC") then return true end
+	if jps.LoseControl(unit,"Snare") then return true end
+	if jps.LoseControl(unit,"Root") then return true end
+	if jps.LoseControl(unit,"Silence") then return true end
 	return false
 end
 
@@ -474,6 +477,8 @@ end
 if jps.IsCastingSpell(2050,"player") and jps.CastTimeLeft(player) > 0.5 and (health_pct_TANK < 0.75) and (manapool > 0.20) then 
 	SpellStopCasting()
 	DEFAULT_CHAT_FRAME:AddMessage("STOPCASTING HEAL",0, 0.5, 0.8)
+-- Avoid interrupt Channeling
+elseif UnitChannelInfo("player")~= nil then return nil
 -- Avoid Overhealing 
 elseif jps.IsCasting("player") and (health_pct_TANK > 0.95) and (not jps.buffId(109964)) and (jps.Target == jps_TANK) then 
 	SpellStopCasting()

--- a/jpevents.lua
+++ b/jpevents.lua
@@ -297,10 +297,11 @@ local function leaveCombat()
     jps.gui_toggleCombat(false)
     jps.EnemyTable = {}
     jps.clearTimeToLive()
-    jps.SortRaidStatus() -- wipe jps.RaidRoster and jps.RaidStatus
-    if jps.getConfigVal("timetodie frame visible") == 1 then
-        JPSEXTInfoFrame:Hide()
-    end
+    jps.SortRaidStatus() -- wipe jps.RaidTarget and jps.RaidStatus
+	-- these lines hide the timetodie frame when in Combat
+    -- if jps.getConfigVal("timetodie frame visible") == 1 then
+        -- JPSEXTInfoFrame:Hide()
+    -- end
     jps.combatStart = 0
 end
 jps.registerEvent("PLAYER_REGEN_ENABLED", leaveCombat)

--- a/jps.lua
+++ b/jps.lua
@@ -322,7 +322,7 @@ function jps_Combat()
 	jps.Lag = select(4,GetNetStats())/1000 -- amount of lag in milliseconds local down, up, lagHome, lagWorld = GetNetStats()
 
 	-- Casting UnitCastingInfo("player")~= nil or UnitChannelInfo("player")~= nil
-	local latency = jps.CastBar.latency
+	local latency = math.max(jps.CastBar.latency,jps.Lag)
 	if jps.ChannelTimeLeft() > 0 then
 		jps.Casting = true
 	elseif (jps.CastTimeLeft() - latency) > 0 then 
@@ -331,38 +331,38 @@ function jps_Combat()
 		jps.Casting = false
 	end
 	
-   -- Check spell usability 
-   if string.len(jps.customRotationFunc) > 10 then
-	   jps.ThisCast,jps.Target = jps.customRotation() 
-   else
-	   jps.ThisCast,jps.Target = jps.activeRotation().getSpell() -- ALLOW SPELLSTOPCASTING() IN JPS.ROTATION() TABLE
-   end
-   if jps.firstInitializingLoop == true then
-	   jps.firstInitializingLoop = false
-	   return nil
-	end
-	
-   -- RAID UPDATE
+	-- RAID UPDATE
 	jps.UpdateHealerBlacklist()
 	-- in case you want to play only with /jps pew the RaidStatus table will be updated
 	if (not jps.Enabled) or (not jps.Combat) then jps.SortRaidStatus() end
    
+	-- Check spell usability 
+	if string.len(jps.customRotationFunc) > 10 then
+	   jps.ThisCast,jps.Target = jps.customRotation() 
+	else
+	   jps.ThisCast,jps.Target = jps.activeRotation().getSpell() -- ALLOW SPELLSTOPCASTING() IN JPS.ROTATION() TABLE
+	end
+	if jps.firstInitializingLoop == true then
+		jps.firstInitializingLoop = false
+		return nil
+	end
+   
    -- Movement
    jps.Moving = GetUnitSpeed("player") > 0
    jps.MovingTarget = GetUnitSpeed("target") > 0
-   
-   if not jps.Casting and jps.ThisCast ~= nil then
-	   if #jps.NextSpell >= 1 then
-		   if jps.NextSpell[1] then
+
+	if not jps.Casting and jps.ThisCast ~= nil then
+		if #jps.NextSpell >= 1 then
+			if jps.NextSpell[1] then
 				jps.Cast(jps.NextSpell[1])
 				table.remove(jps.NextSpell, 1)
-		 else
-			 jps.NextSpell[1] = nil
-		 end
-	  else
-		 jps.Cast(jps.ThisCast)
-	  end
-   end
+			else
+				jps.NextSpell[1] = nil
+			end
+		else
+			jps.Cast(jps.ThisCast)
+		end
+	end
    
    -- Return spellcast.
    return jps.ThisCast,jps.Target

--- a/jputils.lua
+++ b/jputils.lua
@@ -1,5 +1,5 @@
 --[[
-         JPS - WoW Protected Lua DPS AddOn
+    JPS - WoW Protected Lua DPS AddOn
     Copyright (C) 2011 Jp Ganis
 
     This program is free software: you can redistribute it and/or modify
@@ -19,8 +19,8 @@
 --------------------------
 -- LOCALIZATION
 --------------------------
-local L = MyLocalizationTable
 
+local L = MyLocalizationTable
 
 ---------------------------
 -- FUNCTIONS CLASS SPEC

--- a/lib/jpconfig.lua
+++ b/lib/jpconfig.lua
@@ -455,7 +455,7 @@ function jps.DropdownRotationTogle(key, status)
 end
 
 function jps.TimeToDieToggle(key, status)
-	if status == 1 and UnitAffectingCombat("player") ~= nil then
+	if status == 1 and (InCombatLockdown()==1) then
 		JPSEXTInfoFrame:Show()
 	else
 		JPSEXTInfoFrame:Hide()
@@ -506,7 +506,6 @@ function jps.addSpellCheckboxToFrame(spellName)
     rotationJPS_IconOptions_CheckButton:RegisterForClicks("AnyUp");
     rotationJPS_IconOptions_CheckButton:SetScript("OnClick", rotationJPS_IconOptions_CheckButton_OnClick);
     rotationJPS_IconOptions_CheckButton:SetScript("OnShow", rotationJPS_IconOptions_CheckButton_OnShow);
-
     rotationButtonPositionY = rotationButtonPositionY - 30;
 end
 

--- a/modules/jpauras.lua
+++ b/modules/jpauras.lua
@@ -25,7 +25,7 @@ local L = MyLocalizationTable
 -- BUFF DEBUFF
 --------------------------
 -- name, rank, icon, count, debuffType, duration, expirationTime, unitCaster, isStealable, shouldConsolidate, spellId = UnitAura("unit", index or "name"[, "rank"[, "filter"]])
--- name, rank, icon, count, debuffType, duration, expirationTime, unitCaster, isStealable, shouldConsolidate, spellId = UnitDebuff("unit", index or ["name", "rank"][, "filter"]) 
+-- name, rank, icon, count, debuffType, duration, expirationTime, unitCaster, isStealable, shouldConsolidate, spellId = UnitDebuff("unit", index or ["name", "rank"][, "filter"])
 -- name, rank, icon, count, debuffType, duration, expirationTime, unitCaster, isStealable, shouldConsolidate, spellId = UnitBuff("unit", index or ["name", "rank"][, "filter"])
 
 function jps.buffId(spellId,unit)

--- a/modules/jpglobal.lua
+++ b/modules/jpglobal.lua
@@ -19,6 +19,7 @@
 --------------------------
 -- LOCALIZATION
 --------------------------
+
 local L = MyLocalizationTable
 
 --------------------------
@@ -93,8 +94,6 @@ function jps_stringTarget(unit,case)
 return playerName
 end
 
-
-
 ------------------------------
 -- BenPhelps' Timer Functions
 ------------------------------
@@ -147,9 +146,10 @@ function inArray(needle, haystack)
 	return false
 end
 
-function jps_round(val, decimal)
-  local exp = decimal and 10^decimal or 1
-  return math.ceil(val * exp - 0.5) / exp
+function jps_round(num, idp)
+    local mult = 10^(idp or 0)
+    if num >= 0 then return math.floor(num * mult + 0.5) / mult
+    else return math.ceil(num * mult - 0.5) / mult end
 end
 
 ------------------------------

--- a/modules/jphealing.lua
+++ b/modules/jphealing.lua
@@ -1,22 +1,3 @@
---------------------------
--- LOCALIZATION
---------------------------
-
-local L = MyLocalizationTable
-
--- ENEMY UNIT with LOWEST HEALTH
-function jps.LowestInRaidTarget() 
-	local mytarget = nil
-	local lowestHP = 1 
-		for unit,index in pairs(jps.RaidTarget) do
-			local unit_Hpct = index.hpct
-			if unit_Hpct < lowestHP then
-				lowestHP = unit_Hpct
-				mytarget = index.unit
-			end
-		end
-	return mytarget
-end
 
 ------------------------------
 -- SPELLTABLE -- contains the average value of healing spells
@@ -117,8 +98,8 @@ end
 function jps.LowestInRaidStatus() 
 	local lowestUnit = jpsName
 	local lowestHP = 1
-	for unit, unitTable in pairs(jps.RaidStatus) do
-		if (unitTable["inrange"] == true) and unitTable["hpct"] < lowestHP then -- if thisHP < lowestHP 
+	for unit,unitTable in pairs(jps.RaidStatus) do
+		if (unitTable["inrange"] == true) and unitTable["hpct"] < lowestHP then
 			lowestHP = Ternary(jps.isHealer, unitTable["hpct"], jps.hp(unit)) -- if isHealer is disabled get health value from jps.hp() (some "non-healer" rotations uses LowestInRaidStatus)
 			lowestUnit = unit
 		end

--- a/modules/jpitems.lua
+++ b/modules/jpitems.lua
@@ -21,7 +21,6 @@
 --------------------------
 local L = MyLocalizationTable
 
-
 function jps.glovesCooldown()
 	local start, duration, enabled = GetInventoryItemCooldown("player", 10)
 	if enabled==0 then return 999 end
@@ -55,7 +54,6 @@ function jps.useBagItem(itemName)
 	return nil
 end 
 
-
 --------------------------
 -- TRINKET
 --------------------------
@@ -65,6 +63,7 @@ end
 CreateFrame("GameTooltip", "ScanningTooltip", nil, "GameTooltipTemplate") -- Tooltip name cannot be nil
 ScanningTooltip:SetOwner( WorldFrame, "ANCHOR_NONE" )
 ScanningTooltip:ClearLines()
+
 function parseTrinketText(trinket,str)
 	local id = 13 + trinket
 	if trinket > 1 then return false end
@@ -91,7 +90,6 @@ function parseTrinketText(trinket,str)
             		found = true 
             	end
 			end
-			
 		end 
 	end
 	return found
@@ -179,7 +177,7 @@ function jps.useTrinket(trinketNum)
 	local slotName = "Trinket"..(trinketNum).."Slot" -- "Trinket0Slot" "Trinket1Slot"
 	
 	-- Get the slot ID
-	local slotId  = select(1,GetInventorySlotInfo(slotName)) -- "Trinket0Slot" est 13 "Trinket1Slot" est 14
+	local slotId = select(1,GetInventorySlotInfo(slotName)) -- "Trinket0Slot" est 13 "Trinket1Slot" est 14
 
 	return jps.useSlot(slotId)
 end

--- a/modules/jpraid.lua
+++ b/modules/jpraid.lua
@@ -1,5 +1,5 @@
 --[[
-	 JPS - WoW Protected Lua DPS AddOn
+	JPS - WoW Protected Lua DPS AddOn
 	Copyright (C) 2011 Jp Ganis
 
 	This program is free software: you can redistribute it and/or modify
@@ -56,7 +56,6 @@ function jps.findMeAggroTank(targetUnit)
 		return jps.findMeAggroTank()
 	end
 	if jps.Debug then write("found Aggro Tank: "..aggroTank) end
-	
 	return aggroTank
 end
 
@@ -78,7 +77,7 @@ end
 
 function jps.findTanksInRaid() 
 	local myTanks = {}
-	for unitName, _ in pairs(jps.RaidStatus) do
+	for unitName,_ in pairs(jps.RaidStatus) do
 		local foundTank = false
 		if UnitGroupRolesAssigned(unitName) == "TANK" then
 			table.insert(myTanks, unitName);
@@ -129,7 +128,19 @@ function jps.RaidEnemyCount()
 	return enemycount,targetcount
 end
 
-
+-- ENEMY UNIT with LOWEST HEALTH
+function jps.LowestInRaidTarget() 
+local mytarget = nil
+local lowestHP = 1 
+	for unit,index in pairs(jps.RaidTarget) do
+		local unit_Hpct = index.hpct
+		if unit_Hpct < lowestHP then
+			lowestHP = unit_Hpct
+			mytarget = index.unit
+		end
+	end
+return mytarget
+end
 
 -- ENEMY MOST TARGETED
 function jps.RaidTargetUnit()
@@ -143,9 +154,6 @@ function jps.RaidTargetUnit()
 	end
 	return enemyWithMostTargets
 end
-
-
-
 
 -- ENEMY TARGETING THE PLAYER
 -- jps.EnemyTable[enemyGuid] = { ["friend"] = enemyFriend } -- TABLE OF ENEMY GUID TARGETING FRIEND NAME
@@ -166,7 +174,6 @@ function jps.IstargetMe()
 end
 
 -- cast player abilities(for instance deff cd's) if raid encounter applied us a debuff or a ability cd is near finishing or finished
--- 
 
 jps.raid.hasDBM = false
 jps.raid.hasBigWings = false


### PR DESCRIPTION
add a  jps.UnitTimeToDie(unit) to know the jps.LowestTimetoDie() in RaidStatus with jps.RaidTimeToDie Table
change the jps_round in jpglobal
Comment JPSEXTInfoFrame:Hide lines in fct leaveCombat() that hides the timetodie frame when in combat, don't understand why because must be called only when PLAYER_REGEN_ENABLED or PLAYER_UNGHOST fire
