### PR TITLE
warrior fury - new rotation and fatal bug in jpconditionparser

### DIFF
--- a/Rotations/warrior_fury.lua
+++ b/Rotations/warrior_fury.lua
@@ -1,4 +1,4 @@
---kyletxag  & atx 
+--kyletxag	& atx 
 warrior = {}
 function warrior.rangedTarget()
 	local rangedTarget = "target"
@@ -12,6 +12,25 @@ function warrior.rangedTarget()
 	return "target"
 end
 
+function warrior.relativeRage(percentage)
+	local maxRage = 100
+	if jps.glyphInfo(43399) then maxRage = 120 end
+	return maxRage * percentage
+end
+
+function warrior.minColossusSmash()
+return jps.debuffDuration("Colossus Smash") >= 5
+end
+
+--[[[
+@rotation Default
+@class warrior
+@spec fury
+@talents ZZ!!c
+@author atx, kyletxag
+@description 
+This Rotation requires Glyph of Unending Rage. Shouldn't be used at lower levels
+]]--
 jps.registerStaticTable("WARRIOR","FURY",
 	{
 		-- Interrupts
@@ -70,4 +89,81 @@ jps.registerStaticTable("WARRIOR","FURY",
 		
 		{"Wild Strike",'jps.rage() > 106 and jps.cooldown("Colossus Smash") >= 3', warrior.rangedTarget },
 	}
-,"DEFAULT")
+,"Default")
+
+
+
+--[[[
+@rotation Noxxic 5.3
+@class warrior
+@spec fury
+@author Kirk24788
+@description 
+This Rotation is based on Noxxic, but aims to be also used at lower levels.
+This is based on the Default Rotation by atx and kyletxag.
+]]--
+jps.registerStaticTable("WARRIOR","FURY",
+	{
+		-- Interrupts
+		{"Pummel",'jps.shouldKick()'},
+		{"Pummel",'jps.shouldKick("focus")', "focus"},
+		{"Disrupting Shout",'jps.shouldKick()'},
+		{"Disrupting Shout",'jps.shouldKick("focus")', "focus"},
+		
+		-- Cooldowns and Utility
+		{"Victory Rush",'jps.buff("Victorious") and jps.rage() >= 10 and jps.hp("player") < 0.8', warrior.rangedTarget },
+		{"Recklessness",'jps.UseCDs and jps.debuffDuration("Colossus Smash") >= 5', warrior.rangedTarget },
+		{"Recklessness",'jps.UseCDs and jps.cooldown("Colossus Smash") == 0', warrior.rangedTarget },
+		{"Skull Banner",'jps.UseCDs and jps.debuffDuration("Colossus Smash") >= 5', warrior.rangedTarget }, 
+		{"Skull Banner",'jps.UseCDs and jps.cooldown("Colossus Smash") == 0', warrior.rangedTarget }, 
+		
+		{"Berserker Rage",'jps.debuffDuration("Colossus Smash") > 0 and not jps.buff("Berserker Rage","player")', warrior.rangedTarget },
+		{"Bloodbath",'jps.UseCDs'},
+		
+		{ jps.getDPSRacial(),'jps.UseCDs and jps.debuffDuration("Colossus Smash") >= 5'},
+		{ jps.useTrinket(0),'jps.useTrinket(0) ~= nil and jps.UseCDs and jps.debuffDuration("Colossus Smash") >= 5'},
+		{ jps.useTrinket(1),'jps.useTrinket(1) ~= nil and jps.UseCDs and jps.debuffDuration("Colossus Smash") >= 5'},
+		{ jps.useSynapseSprings(),'jps.useSynapseSprings() ~= nil and jps.UseCDs and jps.debuffDuration("Colossus Smash") >= 5'},
+		{"Lifeblood",'jps.UseCDs and jps.debuffDuration("Colossus Smash") >= 5'},
+		
+		-- AoE Rotation
+		{"nested", 'jps.MultiTarget', {
+			{"Whirlwind",'jps.buffStacks("Meat Cleaver") < 3', warrior.rangedTarget },
+			{"Raging Blow",'jps.buffStacks("Meat Cleaver") == 3', warrior.rangedTarget },
+			{"Dragon Roar",'onCD', warrior.rangedTarget },
+		}},
+		
+		{"nested", 'not jps.MultiTarget', {
+			-- Colossus Smash Rotation
+			{"nested", 'jps.mydebuff("Colossus Smash","target")', {
+				{"Bloodthirst",'onCD', warrior.rangedTarget },
+				{"Execute",'jps.hp("target") < 0.2', warrior.rangedTarget}, 
+				{"Heroic Leap",'onCD', warrior.rangedTarget}, 
+				{"Heroic Strike",'onCD', warrior.rangedTarget},
+				{"Raging Blow",'jps.buff("Raging Blow!")', warrior.rangedTarget },
+				{"Wild Strike",'jps.buff("Bloodsurge")', warrior.rangedTarget },
+			}},
+			{"nested", 'jps.Level >= 81', {
+				{"Colossus Smash",'jps.rage() >= warrior.relativeRage(0.75)', warrior.rangedTarget },
+				{"Bloodthirst",'onCD', warrior.rangedTarget },
+				{"Heroic Strike",'jps.rage() >= warrior.relativeRage(0.8)', warrior.rangedTarget },
+				{"Raging Blow",'jps.buffStacks("Raging Blow!") == 2', warrior.rangedTarget },
+				{"Wild Strike",'jps.buff("Bloodsurge")', warrior.rangedTarget },
+				{"Battle Shout",'jps.rage() <= warrior.relativeRage(0.2) and jps.cooldown("Colossus Smash") < 3', "player" },
+				{"Impending Victory",'onCD', warrior.rangedTarget },
+				{"Heroic Throw",'onCD', warrior.rangedTarget },
+			}},
+			{"nested", 'jps.Level < 81', {
+				{"Bloodthirst",'onCD', warrior.rangedTarget },
+				{"Execute",'jps.hp("target") < 0.2', warrior.rangedTarget}, 
+				{"Heroic Leap",'onCD', warrior.rangedTarget}, 
+				{"Impending Victory",'onCD', warrior.rangedTarget },
+				{"Heroic Throw",'onCD', warrior.rangedTarget },
+				{"Heroic Strike",'onCD', warrior.rangedTarget },
+				{"Raging Blow",'jps.buffStacks("Raging Blow!") == 2', warrior.rangedTarget },
+				{"Wild Strike",'jps.buff("Bloodsurge")', warrior.rangedTarget },
+				{"Battle Shout",'jps.rage() <= warrior.relativeRage(0.2)', "player" },
+			}},
+		}},
+	}
+,"Noxxic 5.3")

--- a/jpconditionparser.lua
+++ b/jpconditionparser.lua
@@ -19,7 +19,7 @@ local function fnTargetEval(target)
 end
 
 local function fnConditionEval(conditions)
-    if conditions == nil or conditions == "onCD" then
+    if conditions == nil then
         return true
     elseif type(conditions) == "boolean" then
         return conditions
@@ -493,8 +493,10 @@ end
 
 
 ---[[[ Internal Parsing function - DON'T USE !!! ]]--
+local function alwaysTrue() return true end
 function jps.conditionParser(str)
     if type(str) == "function" then return str end
+    if str == "onCD" then return alwaysTrue() end
     local tokens = {}
     local i = 0
     


### PR DESCRIPTION
Sorry...was a bit late...

I wrote a new Fury Rotation...based on Noxxic which also works for lower level chars (the old rotation did nothing if you didn't have the unending glyph rage....at least not for level 70)
The new rotation should work in raids....can't test, at least it works well below 81...

And there was a major bug in jpconditionparser...."onCD" didn't work...fixed
