### PR TITLE
Update jpparse.lua

### DIFF
--- a/jpparse.lua
+++ b/jpparse.lua
@@ -306,6 +306,8 @@ jps.UserInitiatedSpellsToIgnore = {
 	108978, --alter time
 	12051, --evocation
 	1953, -- blink
+	19263, -- Deterrence
+	781, -- Disengage
 	
 }
 


### PR DESCRIPTION
This (finally) fixes the problem where JPS would waste the second charge of deterrence right after using it manually. 
It also stops jps from casting disengage some seconds after the player wanted to manually cast it. JPS shot me off the blackfuse belt more than once.
How wish i would have found this earlier...
